### PR TITLE
Fix iteration error in deviceMatchesServiceFilter

### DIFF
--- a/libs/evothings/easyble/easyble.js
+++ b/libs/evothings/easyble/easyble.js
@@ -414,11 +414,12 @@
 		{
 			if (advertisementData.kCBAdvDataServiceUUIDs)
 			{
-				for (var i in advertisementData)
+				var advertisedServices = advertisementData.kCBAdvDataServiceUUIDs;
+				for (var i=0; i < advertisedServices.length; i++)
 				{
-					for (var j in serviceFilter)
+					for (var j=0; j < serviceFilter.length; j++)
 					{
-						if (advertisementData[i].toLowerCase() ==
+						if (advertisedServices[i].toLowerCase() ==
 							serviceFilter[j].toLowerCase())
 						{
 							return true;


### PR DESCRIPTION
Fixed the internal `deviceMatchesServicesFilter` function so that `easyble.filterDevicesByService` actually works. Previously, it would iterate over the advertisement data properties instead of the advertised service UUIDs.