### PR TITLE
Correcting getHumidityValues() for Ti SensorTag CC2650.

### DIFF
--- a/libs/evothings/tisensortag/tisensortag-ble-cc2650.js
+++ b/libs/evothings/tisensortag/tisensortag-ble-cc2650.js
@@ -305,6 +305,28 @@
 
 		/**
 		 * SensorTag CC2650.
+		 * Calculate humidity values from raw data.
+		 * @param data - an Uint8Array.
+		 * @return Object with fields: humidityTemperature, relativeHumidity.
+		 * @instance
+		 * @public
+		 */
+		instance.getHumidityValues = function(data)
+		{
+			// Calculate the humidity temperature (Celsius).
+			var tData = evothings.util.littleEndianToInt16(data, 0);
+			var tc = (tData / 65536.0) * 165 - 40;
+
+			// Calculate the relative humidity.
+			var hData = evothings.util.littleEndianToUint16(data, 2);
+			var h = hData * 100 / 65536.0;
+
+			// Return result.
+			return { humidityTemperature: tc, relativeHumidity: h }
+		}
+
+		/**
+		 * SensorTag CC2650.
 		 * Calculate accelerometer values from raw data.
 		 * @param data - an Uint8Array.
 		 * @return Object with fields: x, y, z.


### PR DESCRIPTION
The humidity values reported by the tisensortag-ble-cc2650 library were not correct. The relative humidity would fluctuate to negative values, due to being calculated using the old SensorTag algorithm. The CC2650 SensorTag seems to have changed the format for the data that is sent back. This patch allowed me to have the correct humidity values. I confirmed this by comparing my Javascript app vs the SensorTag app built by Texas Instruments.

See documentation here for how I calculated the humidity values: http://processors.wiki.ti.com/index.php/CC2650_SensorTag_User's_Guide#Data_3